### PR TITLE
DCC 4781 dictionary viewer feature update

### DIFF
--- a/dcc-submission-ui/dictionary/app/index.html
+++ b/dcc-submission-ui/dictionary/app/index.html
@@ -10,6 +10,7 @@
         <link rel="stylesheet" href="styles/docco.css">
         <link rel="stylesheet" href="bower_components/regex-colorizer/themes/nobg.css">
         <link rel="stylesheet" href="bower_components/jsoneditor/dist/jsoneditor.css">
+        <link rel="stylesheet" href="bower_components/jsondiffpatch/public/formatters-styles/html.css">
         <link rel="stylesheet" href="styles/dictionary.css">
         <!-- endbuild -->
     </head>
@@ -41,9 +42,19 @@
         <script src="bower_components/regex-colorizer/regex-colorizer.js"></script>
         <script src="bower_components/d3-tip/index.js"></script>
         <script src="bower_components/jsoneditor/dist/jsoneditor.js"></script>
+        <script src="bower_components/jsondiffpatch/public/build/jsondiffpatch-full.min.js"></script>
 
+        <script>
+            var jsondiffpatch = jsondiffpatch.create({
+              textDiff: {
+                minLength: 10
+                }
+            });
+        </script>
+
+        <script src="bower_components/jsondiffpatch/public/build/jsondiffpatch-formatters.min.js"></script>
         <script src="scripts/vendor/beautify.js"></script>
-
+        
         <script src="scripts/helpers/dictionary-utils.js"></script>
         <script src="scripts/helpers/dictionary-viewer.js"></script>
         <script src="scripts/controllers/dictionary.js"></script>

--- a/dcc-submission-ui/dictionary/app/index.html
+++ b/dcc-submission-ui/dictionary/app/index.html
@@ -43,15 +43,6 @@
         <script src="bower_components/d3-tip/index.js"></script>
         <script src="bower_components/jsoneditor/dist/jsoneditor.js"></script>
         <script src="bower_components/jsondiffpatch/public/build/jsondiffpatch-full.min.js"></script>
-
-        <script>
-            var jsondiffpatch = jsondiffpatch.create({
-              textDiff: {
-                minLength: 10
-                }
-            });
-        </script>
-
         <script src="bower_components/jsondiffpatch/public/build/jsondiffpatch-formatters.min.js"></script>
         <script src="scripts/vendor/beautify.js"></script>
         

--- a/dcc-submission-ui/dictionary/app/scripts/directives/dictionary-viewer-directive.js
+++ b/dcc-submission-ui/dictionary/app/scripts/directives/dictionary-viewer-directive.js
@@ -27,8 +27,9 @@ angular.module('DictionaryViewerApp')
         var _controller = this,
             _firstRun = true,
             _previousVersion = {from: null, to: null};
-
         // Renderer and dictionary logic
+        _controller.state;
+        _controller.lastUpdate;
         _controller.tableViewer = null;
         _controller.dictUtil = null;
         _controller.getCurrentView = DictionaryService.getCurrentViewType;
@@ -287,6 +288,8 @@ angular.module('DictionaryViewerApp')
           _controller.generateChangeList();
           
           _controller.dictUtil.getDictionary(versionTo).then(function (dictTo) {
+            _controller.state = dictTo.state;
+            _controller.lastUpdate = dictTo.lastUpdate;
             _controller.codeLists.forEach(function (codeList) {
               codeList.coverage = _controller.dictUtil.getCodeListCoverage(codeList.name, dictTo).sort();
             });

--- a/dcc-submission-ui/dictionary/app/scripts/directives/dictionary-viewer-directive.js
+++ b/dcc-submission-ui/dictionary/app/scripts/directives/dictionary-viewer-directive.js
@@ -28,8 +28,8 @@ angular.module('DictionaryViewerApp')
             _firstRun = true,
             _previousVersion = {from: null, to: null};
         // Renderer and dictionary logic
-        _controller.state;
-        _controller.lastUpdate;
+        _controller.state = null;
+        _controller.lastUpdate = null;
         _controller.tableViewer = null;
         _controller.dictUtil = null;
         _controller.getCurrentView = DictionaryService.getCurrentViewType;

--- a/dcc-submission-ui/dictionary/app/scripts/directives/dictionary-viewer-directive.js
+++ b/dcc-submission-ui/dictionary/app/scripts/directives/dictionary-viewer-directive.js
@@ -122,6 +122,7 @@ angular.module('DictionaryViewerApp')
           _controller.tableViewer.toggleDataTypeFunc = handleGraphToggle;
 
           _controller.filterChangesReport = function(changeObj) {
+
             var query = _controller.q || '',
                 shouldIncludeObj = true;
 
@@ -142,7 +143,7 @@ angular.module('DictionaryViewerApp')
             // Now for the check default to not including in the filter
             shouldIncludeObj = false;
 
-            ['fileType','fieldName'].map(function (key) {
+            ['type','name'].map(function (key) {
 
               if ( typeof changeObj[key] === 'string' &&
                    normalizeStr(changeObj[key]).indexOf(normalizedQuery) >= 0 ) {
@@ -338,8 +339,6 @@ angular.module('DictionaryViewerApp')
 
           }
 
-
-
           $rootScope.$broadcast(DictionaryViewerConstants.EVENTS.RENDER_COMPLETE, null);
 
           // Skip the rest if our view mode isn't table
@@ -445,4 +444,94 @@ angular.module('DictionaryViewerApp')
       }
     };
 
+  })
+  .directive('reportDataChanges', function($http, $templateCache, $compile, JSONDiffService){    
+    return {      
+      restrict: 'E',
+      replace: true,
+      scope: {
+        changes: '=',
+        type: '@'
+      },
+      link: function($scope, $element, $attrs) {
+        var templateURL = 'scripts/views/data-changes.html',
+            baseURL = '';
+
+        if (angular.isDefined($attrs.templateUrl)) {
+          baseURL = $attrs.templateUrl;
+        }
+        else if (angular.isDefined($attrs.baseDictionaryUrl)) {
+          baseURL = $attrs.baseDictionaryUrl;
+        }
+
+        if (baseURL) {
+          baseURL += '/';
+        }
+
+        $http.get(baseURL + templateURL, {cache: $templateCache}).success(function(tplContent){
+          $element.replaceWith($compile(tplContent)($scope));
+        });
+
+        // $scope.$watch('data', function (newData) {
+        //   console.log(newData);
+        // })
+      }
+    };
+  })
+  .directive('reportDataAddition', function($http, $templateCache, $compile, JSONDiffService){    
+    return {      
+      restrict: 'E',
+      scope: {
+        changes: '=',
+        type: '@'
+      },
+      controllerAs: 'dataAdditionCtrl',
+      link: function($scope, $element, $attrs) {
+        var templateURL = 'scripts/views/data-addition.html',
+            baseURL = '';
+
+        if (angular.isDefined($attrs.templateUrl)) {
+          baseURL = $attrs.templateUrl;
+        }
+        else if (angular.isDefined($attrs.baseDictionaryUrl)) {
+          baseURL = $attrs.baseDictionaryUrl;
+        }
+
+        if (baseURL) {
+          baseURL += '/';
+        }
+
+        $http.get(baseURL + templateURL, {cache: $templateCache}).success(function(tplContent){
+          $element.replaceWith($compile(tplContent)($scope));
+        });
+      }
+    };
+  })
+  .directive('reportDataRemoval', function($http, $templateCache, $compile, JSONDiffService){    
+    return {      
+      restrict: 'E',
+      scope: {
+        changes: '=',
+        type: '@'
+      },
+      link: function($scope, $element, $attrs) {
+        var templateURL = 'scripts/views/data-removal.html',
+            baseURL = '';
+
+        if (angular.isDefined($attrs.templateUrl)) {
+          baseURL = $attrs.templateUrl;
+        }
+        else if (angular.isDefined($attrs.baseDictionaryUrl)) {
+          baseURL = $attrs.baseDictionaryUrl;
+        }
+
+        if (baseURL) {
+          baseURL += '/';
+        }
+
+        $http.get(baseURL + templateURL, {cache: $templateCache}).success(function(tplContent){
+          $element.replaceWith($compile(tplContent)($scope));
+        });
+      }
+    };
   });

--- a/dcc-submission-ui/dictionary/app/scripts/directives/dictionary-viewer-directive.js
+++ b/dcc-submission-ui/dictionary/app/scripts/directives/dictionary-viewer-directive.js
@@ -451,7 +451,8 @@ angular.module('DictionaryViewerApp')
       replace: true,
       scope: {
         changes: '=',
-        type: '@'
+        type: '@',
+        index: '@'
       },
       link: function($scope, $element, $attrs) {
         var templateURL = 'scripts/views/data-changes.html',
@@ -471,10 +472,6 @@ angular.module('DictionaryViewerApp')
         $http.get(baseURL + templateURL, {cache: $templateCache}).success(function(tplContent){
           $element.replaceWith($compile(tplContent)($scope));
         });
-
-        // $scope.$watch('data', function (newData) {
-        //   console.log(newData);
-        // })
       }
     };
   })
@@ -482,10 +479,10 @@ angular.module('DictionaryViewerApp')
     return {      
       restrict: 'E',
       scope: {
-        changes: '=',
-        type: '@'
+        addition: '=',
+        type: '@',
+        index: '@'
       },
-      controllerAs: 'dataAdditionCtrl',
       link: function($scope, $element, $attrs) {
         var templateURL = 'scripts/views/data-addition.html',
             baseURL = '';
@@ -507,12 +504,13 @@ angular.module('DictionaryViewerApp')
       }
     };
   })
-  .directive('reportDataRemoval', function($http, $templateCache, $compile){    
+  .directive('reportDataRemoval', function($http, $templateCache, $compile){   
     return {      
       restrict: 'E',
       scope: {
-        changes: '=',
-        type: '@'
+        removal: '=',
+        type: '@',
+        index: '@'
       },
       link: function($scope, $element, $attrs) {
         var templateURL = 'scripts/views/data-removal.html',

--- a/dcc-submission-ui/dictionary/app/scripts/directives/dictionary-viewer-directive.js
+++ b/dcc-submission-ui/dictionary/app/scripts/directives/dictionary-viewer-directive.js
@@ -445,91 +445,33 @@ angular.module('DictionaryViewerApp')
     };
 
   })
-  .directive('reportDataChanges', function($http, $templateCache, $compile){    
+  .directive('reportDataChanges', function(){    
     return {      
       restrict: 'E',
-      replace: true,
       scope: {
-        changes: '=',
-        type: '@',
-        index: '@'
+        change: '=',
+        type: '@'
       },
-      link: function($scope, $element, $attrs) {
-        var templateURL = 'scripts/views/data-changes.html',
-            baseURL = '';
-
-        if (angular.isDefined($attrs.templateUrl)) {
-          baseURL = $attrs.templateUrl;
-        }
-        else if (angular.isDefined($attrs.baseDictionaryUrl)) {
-          baseURL = $attrs.baseDictionaryUrl;
-        }
-
-        if (baseURL) {
-          baseURL += '/';
-        }
-
-        $http.get(baseURL + templateURL, {cache: $templateCache}).success(function(tplContent){
-          $element.replaceWith($compile(tplContent)($scope));
-        });
-      }
+      templateUrl: 'scripts/views/data-changes.html'
     };
   })
-  .directive('reportDataAddition', function($http, $templateCache, $compile){    
+  .directive('reportDataAddition', function(){    
     return {      
       restrict: 'E',
       scope: {
         addition: '=',
-        type: '@',
-        index: '@'
+        type: '@'
       },
-      link: function($scope, $element, $attrs) {
-        var templateURL = 'scripts/views/data-addition.html',
-            baseURL = '';
-
-        if (angular.isDefined($attrs.templateUrl)) {
-          baseURL = $attrs.templateUrl;
-        }
-        else if (angular.isDefined($attrs.baseDictionaryUrl)) {
-          baseURL = $attrs.baseDictionaryUrl;
-        }
-
-        if (baseURL) {
-          baseURL += '/';
-        }
-
-        $http.get(baseURL + templateURL, {cache: $templateCache}).success(function(tplContent){
-          $element.replaceWith($compile(tplContent)($scope));
-        });
-      }
+      templateUrl: 'scripts/views/data-addition.html'
     };
   })
-  .directive('reportDataRemoval', function($http, $templateCache, $compile){   
+  .directive('reportDataRemoval', function(){   
     return {      
       restrict: 'E',
       scope: {
         removal: '=',
-        type: '@',
-        index: '@'
+        type: '@'
       },
-      link: function($scope, $element, $attrs) {
-        var templateURL = 'scripts/views/data-removal.html',
-            baseURL = '';
-
-        if (angular.isDefined($attrs.templateUrl)) {
-          baseURL = $attrs.templateUrl;
-        }
-        else if (angular.isDefined($attrs.baseDictionaryUrl)) {
-          baseURL = $attrs.baseDictionaryUrl;
-        }
-
-        if (baseURL) {
-          baseURL += '/';
-        }
-
-        $http.get(baseURL + templateURL, {cache: $templateCache}).success(function(tplContent){
-          $element.replaceWith($compile(tplContent)($scope));
-        });
-      }
+      templateUrl: 'scripts/views/data-removal.html'
     };
   });

--- a/dcc-submission-ui/dictionary/app/scripts/directives/dictionary-viewer-directive.js
+++ b/dcc-submission-ui/dictionary/app/scripts/directives/dictionary-viewer-directive.js
@@ -445,7 +445,7 @@ angular.module('DictionaryViewerApp')
     };
 
   })
-  .directive('reportDataChanges', function($http, $templateCache, $compile, JSONDiffService){    
+  .directive('reportDataChanges', function($http, $templateCache, $compile){    
     return {      
       restrict: 'E',
       replace: true,
@@ -478,7 +478,7 @@ angular.module('DictionaryViewerApp')
       }
     };
   })
-  .directive('reportDataAddition', function($http, $templateCache, $compile, JSONDiffService){    
+  .directive('reportDataAddition', function($http, $templateCache, $compile){    
     return {      
       restrict: 'E',
       scope: {
@@ -507,7 +507,7 @@ angular.module('DictionaryViewerApp')
       }
     };
   })
-  .directive('reportDataRemoval', function($http, $templateCache, $compile, JSONDiffService){    
+  .directive('reportDataRemoval', function($http, $templateCache, $compile){    
     return {      
       restrict: 'E',
       scope: {

--- a/dcc-submission-ui/dictionary/app/scripts/filters/dictionary-viewer-filters.js
+++ b/dcc-submission-ui/dictionary/app/scripts/filters/dictionary-viewer-filters.js
@@ -7,4 +7,8 @@ angular.module('DictionaryViewerApp')
     return function(input) {
       return angular.isDefined(prettyPrintViewMap[input]) ? prettyPrintViewMap[input] : input;
     };
-  });
+  }).filter('sanitize', ['$sce', function($sce) {
+    return function(htmlCode){
+      return $sce.trustAsHtml(htmlCode);
+    };
+  }]);

--- a/dcc-submission-ui/dictionary/app/scripts/filters/dictionary-viewer-filters.js
+++ b/dcc-submission-ui/dictionary/app/scripts/filters/dictionary-viewer-filters.js
@@ -21,5 +21,5 @@ angular.module('DictionaryViewerApp')
       });
     }, function resolver (data) {
       return _.pluck(data, 'id');
-    })
+    });
   });

--- a/dcc-submission-ui/dictionary/app/scripts/filters/dictionary-viewer-filters.js
+++ b/dcc-submission-ui/dictionary/app/scripts/filters/dictionary-viewer-filters.js
@@ -7,8 +7,19 @@ angular.module('DictionaryViewerApp')
     return function(input) {
       return angular.isDefined(prettyPrintViewMap[input]) ? prettyPrintViewMap[input] : input;
     };
-  }).filter('sanitize', ['$sce', function($sce) {
+  })
+  .filter('sanitize', ['$sce', function($sce) {
     return function(htmlCode){
       return $sce.trustAsHtml(htmlCode);
     };
-  }]);
+  }])
+  .filter('findDiffs', function (JSONDiffService) {
+    return _.memoize(function (data) {
+      return data.map(function (node) {
+        var diff = JSONDiffService.formatDifferences(node.from, node.to);
+        return _.extend({}, node, { diff : diff});
+      });
+    }, function resolver (data) {
+      return _.pluck(data, 'id');
+    })
+  });

--- a/dcc-submission-ui/dictionary/app/scripts/helpers/dictionary-utils.js
+++ b/dcc-submission-ui/dictionary/app/scripts/helpers/dictionary-utils.js
@@ -1,4 +1,4 @@
-/* globals $,jsondiffpatch */
+/* globals $ */
 'use strict';
 
 var dictionaryApp = dictionaryApp || {};
@@ -102,8 +102,7 @@ var dictionaryApp = dictionaryApp || {};
      return _.find(file.fields, function(f) { return f.name === fieldname; });
    };
 
-   DictionaryUtil.prototype.getFilePatternDiff = function(dict, tableTo) {
-     var tableFrom = this.getFileTypeFromDict(dict, tableTo.name);
+   DictionaryUtil.prototype.getFilePatternDiff = function(tableFrom, tableTo) {
 
       if (!tableFrom) {
         return null;
@@ -112,9 +111,8 @@ var dictionaryApp = dictionaryApp || {};
       return _.isEqual(tableFrom.pattern, tableTo.pattern);
    };
 
-   DictionaryUtil.prototype.getFileLabelDiff = function(dict, tableTo) {
-      var tableFrom = this.getFileTypeFromDict(dict, tableTo.name);
-
+   DictionaryUtil.prototype.getFileLabelDiff = function(tableFrom, tableTo) {
+     
       if (!tableFrom) {
         return null;
       }
@@ -224,10 +222,33 @@ var dictionaryApp = dictionaryApp || {};
       report.fieldsChanged = [];
       report.fileDataChanged = [];
 
+      function addDiff (diffType, entry) {
+        var entryWithIndex = _.extend({
+          id: _.uniqueId()
+        }, entry);
+
+        switch (diffType) {
+          case 'fieldsAdded':
+            report.fieldsAdded.push(entryWithIndex);
+            break;
+          case 'fieldsRemoved':
+            report.fieldsRemoved.push(entryWithIndex);
+            break;
+          case 'fieldsChanged':
+            report.fieldsChanged.push(entryWithIndex);
+            break;
+          case 'fileDataChanged':
+            report.fileDataChanged.push(entryWithIndex);
+            break;
+          default: 
+            throw new Error('unsupported diffType');
+        }
+      }
+
       return _self.getDictionary(versionFrom).then(function (dictFrom) {
         return _self.getDictionary(versionTo).then(function (dictTo) {      
 
-          //Sorting dictionary files
+          // Sorting dictionary files
           dictFrom.files = _.sortBy(dictFrom.files, function (d) {
             return _self.sortingOrder().indexOf(d.name);
           });   
@@ -239,36 +260,38 @@ var dictionaryApp = dictionaryApp || {};
           // Scan for changed and remove file types
           if (dictFrom.files) {
             dictFrom.files.forEach(function (fileFrom) {
-               var fileTo = _self.getFileTypeFromDict(dictTo, fileFrom.name);
+              var fileTo = _self.getFileTypeFromDict(dictTo, fileFrom.name);
                
               // If no file, then it as been removed.
               // Otherwise we need to check each field for changes.
               if (!fileTo) {
                 fileFrom.fields.forEach(function (fieldFrom) {
-                  report.fieldsRemoved.push({
-                    fileType: fileFrom.name,
-                    fieldName: fieldFrom.name,
-                    fieldDiff: jsondiffpatch.formatters.html.format(jsondiffpatch.diff(fileFrom, {}))
+                  addDiff('fieldsRemoved', {
+                    type: fileFrom.name,
+                    name: fieldFrom.name,
+                    from: fileFrom,
+                    to: {}
                   });
                 });
               } else {
                 // Check file metadata change
-
                 if(!_.isEqual(fileFrom, fileTo)){
 
-                  if(!_self.getFileLabelDiff(dictFrom, fileTo)){
-                    report.fileDataChanged.push({
-                      fileType: fileTo.name,
-                      fileChange: fileTo.label,
-                      fileDiff: jsondiffpatch.formatters.html.format(jsondiffpatch.diff(fileFrom, fileTo).label)
+                  if(!_self.getFileLabelDiff(fileFrom, fileTo)){
+                    addDiff('fileDataChanged', {
+                      type: fileTo.name,
+                      name: fileTo.label,
+                      from: fileFrom.label,
+                      to:  fileTo.label
                     });
                   }
 
-                  if(!_self.getFilePatternDiff(dictFrom, fileTo)){
-                    report.fileDataChanged.push({
-                      fileType: fileTo.name,
-                      fileChange: 'File Name Pattern',
-                      fileDiff: jsondiffpatch.formatters.html.format(jsondiffpatch.diff(fileFrom, fileTo).pattern)
+                  if(!_self.getFilePatternDiff(fileFrom, fileTo)){
+                    addDiff('fileDataChanged', {
+                      type: fileTo.name,
+                      name: 'File Name Pattern',
+                      from: fileFrom.pattern,
+                      to:  fileTo.pattern
                     });
                   }
                 }
@@ -278,19 +301,21 @@ var dictionaryApp = dictionaryApp || {};
                   var fieldTo = _self.getFieldFromDict(dictTo, fileFrom.name, fieldFrom.name);
 
                   if (!fieldTo) {
-                    report.fieldsRemoved.push({
-                      fileType: fileFrom.name,
-                      fieldName: fieldFrom.name,
-                      fieldDiff: jsondiffpatch.formatters.html.format(jsondiffpatch.diff(fieldFrom, fieldTo))
+                    addDiff('fieldsRemoved', {
+                      type: fileFrom.name,
+                      name: fieldFrom.name,
+                      from: fieldFrom,
+                      to: fieldTo
                     });
                   } else if (_self.isDifferent2(fieldTo, fieldFrom).length > 0) {
-                    var difference = _.omit(jsondiffpatch.diff(fieldFrom, fieldTo), 'expanded');
+                    // var difference = _.omit(jsondiffpatch.diff(fieldFrom, fieldTo), 'expanded');
 
-                    report.fieldsChanged.push({
-                      fileType: fileFrom.name,
-                      fieldName: fieldFrom.name,
+                    addDiff('fieldsChanged', {
+                      type: fileFrom.name,
+                      name: fieldFrom.name,
                       changes: _self.isDifferent2(fieldTo, fieldFrom),
-                      fieldDiff: jsondiffpatch.formatters.html.format(difference)
+                      from: fieldFrom,
+                      to: fieldTo
                     });
                   }
                 });
@@ -299,10 +324,11 @@ var dictionaryApp = dictionaryApp || {};
                 fileTo.fields.forEach(function (fieldTo) {
                   var fieldFrom = _self.getFieldFromDict(dictFrom, fileTo.name, fieldTo.name);
                   if (!fieldFrom) {
-                    report.fieldsAdded.push({
-                      fileType: fileTo.name,
-                      fieldName: fieldTo.name,
-                      fieldDiff: jsondiffpatch.formatters.html.format(jsondiffpatch.diff(fieldFrom, fieldTo))
+                    addDiff('fieldsAdded', {
+                      type: fileTo.name,
+                      name: fieldTo.name,
+                      from: fieldFrom,
+                      to: fieldTo
                     });
                   }
                 });
@@ -317,10 +343,11 @@ var dictionaryApp = dictionaryApp || {};
               // fileTo is new
               if (!fileFrom) {
                 fileTo.fields.forEach(function (fieldTo) {
-                  report.fieldsAdded.push({
-                    fileType: fileTo.name,
-                    fieldName: fieldTo.name,
-                    fieldDiff: jsondiffpatch.formatters.html.format(jsondiffpatch.diff({}, fieldTo))
+                  addDiff('fieldsAdded', {
+                    type: fileTo.name,
+                    name: fieldTo.name,
+                    from: {},
+                    To: fieldTo
                   });
                 });
               }

--- a/dcc-submission-ui/dictionary/app/scripts/helpers/dictionary-utils.js
+++ b/dcc-submission-ui/dictionary/app/scripts/helpers/dictionary-utils.js
@@ -1,4 +1,4 @@
-/* globals $ */
+/* globals $,jsondiffpatch */
 'use strict';
 
 var dictionaryApp = dictionaryApp || {};

--- a/dcc-submission-ui/dictionary/app/scripts/helpers/dictionary-utils.js
+++ b/dcc-submission-ui/dictionary/app/scripts/helpers/dictionary-utils.js
@@ -102,7 +102,25 @@ var dictionaryApp = dictionaryApp || {};
      return _.find(file.fields, function(f) { return f.name === fieldname; });
    };
 
+   DictionaryUtil.prototype.getFilePatternDiff = function(dict, tableTo) {
+     var tableFrom = this.getFileTypeFromDict(dict, tableTo.name);
 
+      if (!tableFrom) {
+        return null;
+      }
+
+      return _.isEqual(tableFrom.pattern, tableTo.pattern);
+   };
+
+   DictionaryUtil.prototype.getFileLabelDiff = function(dict, tableTo) {
+      var tableFrom = this.getFileTypeFromDict(dict, tableTo.name);
+
+      if (!tableFrom) {
+        return null;
+      }
+      
+      return _.isEqual(tableFrom.label, tableTo.label);
+   };
 
    ////////////////////////////////////////////////////////////////////////////////
    // How the files should be sorted
@@ -204,6 +222,7 @@ var dictionaryApp = dictionaryApp || {};
       report.fieldsAdded   = [];
       report.fieldsRemoved = [];
       report.fieldsChanged = [];
+      report.fileDataChanged = [];
 
       return _self.getDictionary(versionFrom).then(function (dictFrom) {
         return _self.getDictionary(versionTo).then(function (dictTo) {
@@ -223,6 +242,25 @@ var dictionaryApp = dictionaryApp || {};
                   });
                 });
               } else {
+                // Check file metadata change
+
+                if(!_.isEqual(fileFrom, fileTo)){
+
+                  if(!_self.getFileLabelDiff(dictFrom, fileTo)){
+                    report.fileDataChanged.push({
+                      fileType: fileTo.name,
+                      fileChange: fileTo.label
+                    });
+                  }
+
+                  if(!_self.getFilePatternDiff(dictFrom, fileTo)){
+                    report.fileDataChanged.push({
+                      fileType: fileTo.name,
+                      fileChange: 'File Name Pattern'
+                    });
+                  }
+                }
+                
                 // Check removed and changed
                 fileFrom.fields.forEach(function (fieldFrom) {
                   var fieldTo = _self.getFieldFromDict(dictTo, fileFrom.name, fieldFrom.name);

--- a/dcc-submission-ui/dictionary/app/scripts/helpers/dictionary-utils.js
+++ b/dcc-submission-ui/dictionary/app/scripts/helpers/dictionary-utils.js
@@ -347,7 +347,7 @@ var dictionaryApp = dictionaryApp || {};
                     type: fileTo.name,
                     name: fieldTo.name,
                     from: {},
-                    To: fieldTo
+                    to: fieldTo
                   });
                 });
               }

--- a/dcc-submission-ui/dictionary/app/scripts/helpers/dictionary-viewer.js
+++ b/dcc-submission-ui/dictionary/app/scripts/helpers/dictionary-viewer.js
@@ -187,7 +187,8 @@ var dictionaryApp = dictionaryApp || {};
 
           if(filePatternDiff){
             metadataTableBody.append('tr')
-              .html('<td class="data-diff"></td><th>File Name Pattern:</th><td class="regex">' + table.pattern + '</td>');
+              .html('<td class="data-diff"></td><th>File Name Pattern:</th><td class="regex">' + 
+              table.pattern + '</td>');
           }else{
             metadataTableBody.append('tr')
               .html('<td></td><th>File Name Pattern:</th><td class="regex">' + table.pattern + '</td>');

--- a/dcc-submission-ui/dictionary/app/scripts/helpers/dictionary-viewer.js
+++ b/dcc-submission-ui/dictionary/app/scripts/helpers/dictionary-viewer.js
@@ -170,11 +170,29 @@ var dictionaryApp = dictionaryApp || {};
 
           var metadataTableBody = metadataTable.append('tbody');
 
-          metadataTableBody.append('tr').html('<th>File Type:</th><td>' + table.label + '</td>');
-          metadataTableBody.append('tr').html('<th>File Key:</th><td>' + table.name + '</td>');
-          metadataTableBody.append('tr')
-            .html('<th>File Name Pattern:</th><td class="regex">' + table.pattern + '</td>');
+          var filePatternDiff = !_self.dictUtil.getFilePatternDiff(dictFrom, table);
+          var fileLabelDiff = !_self.dictUtil.getFileLabelDiff(dictFrom, table);
+          
 
+          if(fileLabelDiff){
+            metadataTableBody.append('tr')
+                           .html('<td class="data-diff"></td><th>File Type:</th><td>' + table.label + '</td>');
+          }else{
+            metadataTableBody.append('tr')
+                           .html('<td></td><th>File Type:</th><td>' + table.label + '</td>');
+          }
+
+          metadataTableBody.append('tr')
+                             .html('<td></td><th>File Key:</th><td>' + table.name + '</td>');
+
+          if(filePatternDiff){
+            metadataTableBody.append('tr')
+                             .html('<td class="data-diff"></td><th>File Name Pattern:</th><td class="regex">' + table.pattern + '</td>');
+          }else{
+            metadataTableBody.append('tr')
+                             .html('<td></td><th>File Name Pattern:</th><td class="regex">' + table.pattern + '</td>');
+          }
+          
 
           // Create the minimap things
           var realH = Math.max(_self.barHeight, 5 + table.fields.length);

--- a/dcc-submission-ui/dictionary/app/scripts/helpers/dictionary-viewer.js
+++ b/dcc-submission-ui/dictionary/app/scripts/helpers/dictionary-viewer.js
@@ -176,21 +176,21 @@ var dictionaryApp = dictionaryApp || {};
 
           if(fileLabelDiff){
             metadataTableBody.append('tr')
-                           .html('<td class="data-diff"></td><th>File Type:</th><td>' + table.label + '</td>');
+              .html('<td class="data-diff"></td><th>File Type:</th><td>' + table.label + '</td>');
           }else{
             metadataTableBody.append('tr')
-                           .html('<td></td><th>File Type:</th><td>' + table.label + '</td>');
+              .html('<td></td><th>File Type:</th><td>' + table.label + '</td>');
           }
 
           metadataTableBody.append('tr')
-                             .html('<td></td><th>File Key:</th><td>' + table.name + '</td>');
+            .html('<td></td><th>File Key:</th><td>' + table.name + '</td>');
 
           if(filePatternDiff){
             metadataTableBody.append('tr')
-                             .html('<td class="data-diff"></td><th>File Name Pattern:</th><td class="regex">' + table.pattern + '</td>');
+              .html('<td class="data-diff"></td><th>File Name Pattern:</th><td class="regex">' + table.pattern + '</td>');
           }else{
             metadataTableBody.append('tr')
-                             .html('<td></td><th>File Name Pattern:</th><td class="regex">' + table.pattern + '</td>');
+              .html('<td></td><th>File Name Pattern:</th><td class="regex">' + table.pattern + '</td>');
           }
           
 

--- a/dcc-submission-ui/dictionary/app/scripts/services/dictionary-viewer-service.js
+++ b/dcc-submission-ui/dictionary/app/scripts/services/dictionary-viewer-service.js
@@ -150,4 +150,25 @@ angular.module('DictionaryViewerApp')
       
     }
 
+  })
+  .service('JSONDiffService', function($window){
+    var _service = this,
+      _formatService = $window.jsondiffpatch,
+      _diffService = _formatService.create({ textDiff: { minLength: 10 }});
+
+
+    _service.getDifferences = function(from, to){
+      var differences = _diffService.diff(from, to);
+
+      if(_.has(differences, 'expanded')){
+        differences = _.omit(differences, 'expanded');
+      }
+
+      return differences;
+    };
+
+    _service.formatDifferences = function(from, to){
+      return _formatService.formatters.html.format(_service.getDifferences(from, to));
+    };
+
   });

--- a/dcc-submission-ui/dictionary/app/scripts/services/dictionary-viewer-service.js
+++ b/dcc-submission-ui/dictionary/app/scripts/services/dictionary-viewer-service.js
@@ -35,7 +35,6 @@ angular.module('DictionaryViewerApp')
       var deferred = $q.defer(),
           webserviceURL = (baseURL || '') + '/ws';
 
-
       $http.get(webserviceURL + '/dictionaries/versions')
         .then(function (dictionaryList) {
 
@@ -145,9 +144,6 @@ angular.module('DictionaryViewerApp')
 
       return _dictionaryUtils.createDiffListing(_versionRange.from, _versionRange.to).then(function (report) {
         changeReport = report;
-        changeReport.changed = changeReport.fieldsChanged;
-        changeReport.added = changeReport.fieldsAdded;
-        changeReport.removed = changeReport.fieldsRemoved;
 
         return changeReport;
       });

--- a/dcc-submission-ui/dictionary/app/scripts/views/data-addition.html
+++ b/dcc-submission-ui/dictionary/app/scripts/views/data-addition.html
@@ -1,5 +1,5 @@
 <i class="fa fa-plus"></i>
 <span data-ng-bind-template="{{addition.type}} - {{addition.name}}"></span>
-<div class="collapse content" id="{{type}}{{index}}" data-ng-if="addition.diff" >
-<div class="well" data-ng-bind-html="addition.diff | sanitize"></div>
+<div class="collapse content" id="{{type}}{{addition.id}}" data-ng-if="addition.diff" >
+  <div class="well" data-ng-bind-html="addition.diff | sanitize"></div>
 </div>

--- a/dcc-submission-ui/dictionary/app/scripts/views/data-addition.html
+++ b/dcc-submission-ui/dictionary/app/scripts/views/data-addition.html
@@ -1,11 +1,5 @@
-<li 
-  data-toggle="collapse" 
-  data-target="#{{type}}{{$index}}" 
-  aria-expanded="false" 
-  data-ng-repeat="addition in changes | findDiffs track by addition.id">
-  <i class="fa fa-plus"></i>
-  <span data-ng-bind-template="{{addition.type}} - {{addition.name}}"></span>
-  <div class="collapse content" id="{{type}}{{$index}}" data-ng-if="addition.diff" >
-    <div class="well" data-ng-bind-html="addition.diff | sanitize"></div>
-  </div>
-</li>
+<i class="fa fa-plus"></i>
+<span data-ng-bind-template="{{addition.type}} - {{addition.name}}"></span>
+<div class="collapse content" id="{{type}}{{index}}" data-ng-if="addition.diff" >
+<div class="well" data-ng-bind-html="addition.diff | sanitize"></div>
+</div>

--- a/dcc-submission-ui/dictionary/app/scripts/views/data-addition.html
+++ b/dcc-submission-ui/dictionary/app/scripts/views/data-addition.html
@@ -1,0 +1,11 @@
+<li 
+  data-toggle="collapse" 
+  data-target="#{{type}}{{$index}}" 
+  aria-expanded="false" 
+  data-ng-repeat="addition in changes | findDiffs track by addition.id">
+  <i class="fa fa-plus"></i>
+  <span data-ng-bind-template="{{addition.type}} - {{addition.name}}"></span>
+  <div class="collapse content" id="{{type}}{{$index}}" data-ng-if="addition.diff" >
+    <div class="well" data-ng-bind-html="addition.diff | sanitize"></div>
+  </div>
+</li>

--- a/dcc-submission-ui/dictionary/app/scripts/views/data-changes.html
+++ b/dcc-submission-ui/dictionary/app/scripts/views/data-changes.html
@@ -1,11 +1,5 @@
-<li 
-  data-toggle="collapse" 
-  data-target="#{{type}}{{$index}}" 
-  aria-expanded="false" 
-  data-ng-repeat="change in changes | findDiffs track by change.id" >
-  <i class="fa fa-exchange"></i> 
-  <span data-ng-bind-template="{{change.type}} - {{change.name}}"></span>
-  <div class="collapse content" id="{{type}}{{$index}}" data-ng-if="change.diff" >
-    <div class="well" data-ng-bind-html="change.diff | sanitize"></div>
-  </div>
-</li>
+<i class="fa fa-exchange"></i> 
+<span data-ng-bind-template="{{changes.type}} - {{changes.name}}"></span>
+<div class="collapse content" id="{{type}}{{index}}" data-ng-if="changes.diff" >
+<div class="well" data-ng-bind-html="changes.diff | sanitize"></div>
+</div>

--- a/dcc-submission-ui/dictionary/app/scripts/views/data-changes.html
+++ b/dcc-submission-ui/dictionary/app/scripts/views/data-changes.html
@@ -1,0 +1,11 @@
+<li 
+  data-toggle="collapse" 
+  data-target="#{{type}}{{$index}}" 
+  aria-expanded="false" 
+  data-ng-repeat="change in changes | findDiffs track by change.id" >
+  <i class="fa fa-exchange"></i> 
+  <span data-ng-bind-template="{{change.type}} - {{change.name}}"></span>
+  <div class="collapse content" id="{{type}}{{$index}}" data-ng-if="change.diff" >
+    <div class="well" data-ng-bind-html="change.diff | sanitize"></div>
+  </div>
+</li>

--- a/dcc-submission-ui/dictionary/app/scripts/views/data-changes.html
+++ b/dcc-submission-ui/dictionary/app/scripts/views/data-changes.html
@@ -1,5 +1,5 @@
 <i class="fa fa-exchange"></i> 
-<span data-ng-bind-template="{{changes.type}} - {{changes.name}}"></span>
-<div class="collapse content" id="{{type}}{{index}}" data-ng-if="changes.diff" >
-<div class="well" data-ng-bind-html="changes.diff | sanitize"></div>
+<span data-ng-bind-template="{{change.type}} - {{change.name}}"></span>
+<div class="collapse content" id="{{type}}{{change.id}}" data-ng-if="change.diff" >
+  <div class="well" data-ng-bind-html="change.diff | sanitize"></div>
 </div>

--- a/dcc-submission-ui/dictionary/app/scripts/views/data-removal.html
+++ b/dcc-submission-ui/dictionary/app/scripts/views/data-removal.html
@@ -1,11 +1,5 @@
-<li 
-  data-toggle="collapse" 
-  data-target="#{{type}}{{$index}}" 
-  aria-expanded="false" 
-  data-ng-repeat="removal in changes | findDiffs track by removal.id">
-  <i class="fa fa-minus"></i>
-  <span data-ng-bind-template="{{removal.type}} - {{removal.name}}"></span>
-  <div class="collapse content" id="{{type}}{{$index}}" data-ng-if="removal.diff" >
-    <div class="well" data-ng-bind-html="removal.diff | sanitize"></div>
-  </div>
-</li>
+<i class="fa fa-minus"></i>
+<span data-ng-bind-template="{{removal.type}} - {{removal.name}}"></span>
+<div class="collapse content" id="{{type}}{{index}}" data-ng-if="removal.diff" >
+  <div class="well" data-ng-bind-html="removal.diff | sanitize"></div>
+</div>

--- a/dcc-submission-ui/dictionary/app/scripts/views/data-removal.html
+++ b/dcc-submission-ui/dictionary/app/scripts/views/data-removal.html
@@ -1,0 +1,11 @@
+<li 
+  data-toggle="collapse" 
+  data-target="#{{type}}{{$index}}" 
+  aria-expanded="false" 
+  data-ng-repeat="removal in changes | findDiffs track by removal.id">
+  <i class="fa fa-minus"></i>
+  <span data-ng-bind-template="{{removal.type}} - {{removal.name}}"></span>
+  <div class="collapse content" id="{{type}}{{$index}}" data-ng-if="removal.diff" >
+    <div class="well" data-ng-bind-html="removal.diff | sanitize"></div>
+  </div>
+</li>

--- a/dcc-submission-ui/dictionary/app/scripts/views/data-removal.html
+++ b/dcc-submission-ui/dictionary/app/scripts/views/data-removal.html
@@ -1,5 +1,5 @@
 <i class="fa fa-minus"></i>
 <span data-ng-bind-template="{{removal.type}} - {{removal.name}}"></span>
-<div class="collapse content" id="{{type}}{{index}}" data-ng-if="removal.diff" >
+<div class="collapse content" id="{{type}}{{removal.id}}" data-ng-if="removal.diff" >
   <div class="well" data-ng-bind-html="removal.diff | sanitize"></div>
 </div>

--- a/dcc-submission-ui/dictionary/app/scripts/views/dictionary-viewer-directive.html
+++ b/dcc-submission-ui/dictionary/app/scripts/views/dictionary-viewer-directive.html
@@ -151,10 +151,18 @@
                             <h3 class="change-modification-header"><i class="fa fa-exchange"></i> File Data Modifications</h3>
                             <div class="change-report-container change-modifications">
                                 <ul class="change-report-list">
-                                    <report-data-changes
-                                        changes="dictionaryViewerCtrl.changeReport.fileDataChanged" 
-                                        type="fileChanged">
-                                    </report-data-changes>
+                                    <li data-toggle="collapse" 
+                                      data-target="#fileChanged{{$index}}" 
+                                      aria-expanded="false" 
+                                      data-ng-repeat="changes in dictionaryViewerCtrl.changeReport.fileDataChanged 
+                                        | filter: dictionaryViewerCtrl.filterChangesReport 
+                                        | findDiffs track by changes.id" >                                      
+                                      <report-data-changes
+                                        changes="changes" 
+                                        type="fileChanged"
+                                        index="{{$index}}">
+                                      </report-data-changes>
+                                    </li>
                                 </ul>
                             </div>
                         </div>
@@ -164,7 +172,17 @@
                             <h3 class="change-addition-header"><i class="fa fa-plus"></i> Field Name Additions</h3>
                             <div class="change-report-container change-additions">
                                 <ul class="change-report-list">
-                                    <report-data-addition changes="dictionaryViewerCtrl.changeReport.fieldsAdded" type="fieldAdded"></report-data-addition>
+                                  <li data-toggle="collapse" 
+                                    data-target="#fieldAdded{{$index}}" 
+                                    aria-expanded="false" 
+                                    data-ng-repeat="additions in dictionaryViewerCtrl.changeReport.fieldsAdded
+                                      | filter: dictionaryViewerCtrl.filterChangesReport
+                                      | findDiffs track by additions.id">
+                                    <report-data-addition 
+                                      addition="additions" 
+                                      type="fieldAdded"
+                                      index="{{$index}}">
+                                    </report-data-addition>
                                 </ul>
                             </div>
                         </div>
@@ -172,26 +190,37 @@
                             <h3 class="change-modification-header"><i class="fa fa-exchange"></i> Field Name Modifications</h3>
                             <div class="change-report-container change-modifications">
                                 <ul class="change-report-list">
-                                    <report-data-changes changes="dictionaryViewerCtrl.changeReport.fieldsChanged" type="fieldChange"></report-data-changes>
+                                  <li data-toggle="collapse" 
+                                    data-target="#fieldChange{{$index}}" 
+                                    aria-expanded="false" 
+                                    data-ng-repeat="change in dictionaryViewerCtrl.changeReport.fieldsChanged 
+                                      | filter: dictionaryViewerCtrl.filterChangesReport 
+                                      | findDiffs track by change.id" >
+                                    <report-data-changes 
+                                      changes="change" 
+                                      type="fieldChange"
+                                      index="{{$index}}">
+                                    </report-data-changes>
                                 </ul>
                             </div>
                         </div>
                         <div id="field-deletions" data-ng-if="dictionaryViewerCtrl.changeReport.fieldsRemoved.length">
                             <h3 class="change-removal-header"><i class="fa fa-minus"></i> Field Name Deletions</h3>
                             <div class="change-report-container change-removals">
-
                                 <ul class="change-report-list">
-                                    <report-data-removal changes="dictionaryViewerCtrl.changeReport.fieldsRemoved" type="fieldsRemoved"></report-data-removal>
-                                    <!--<li
+                                    <li
                                       data-toggle="collapse" 
                                       data-target="#fieldRemoved{{$index}}" 
                                       aria-expanded="false"  
-                                      data-ng-repeat="removal in dictionaryViewerCtrl.changeReport.fieldsRemoved | filter: dictionaryViewerCtrl.filterChangesReport">
-                                        <i class="fa fa-minus"></i> <span data-ng-bind-template="{{removal.fileType}} - {{removal.fieldName}}"></span>
-                                        <div class="collapse content" id="fieldRemoved{{$index}}" data-ng-if="removal.fieldDiff">
-                                          <div class="well" data-ng-bind-html="removal.fieldDiff | sanitize"></div>
-                                        </div>
-                                    </li>-->
+                                      data-ng-repeat="removals in dictionaryViewerCtrl.changeReport.fieldsRemoved 
+                                        | filter: dictionaryViewerCtrl.filterChangesReport
+                                        | findDiffs track by removals.id">
+                                        <report-data-removal 
+                                          removal="removals" 
+                                          type="fieldRemoved"
+                                          index="{{$index}}">
+                                        </report-data-removal>
+                                    </li>
                                 </ul>
                             </div>
                         </div>

--- a/dcc-submission-ui/dictionary/app/scripts/views/dictionary-viewer-directive.html
+++ b/dcc-submission-ui/dictionary/app/scripts/views/dictionary-viewer-directive.html
@@ -143,15 +143,24 @@
             <div data-ng-class="{'active': dictionaryViewerCtrl.getCurrentView() === 'report'}"
                  class="tab-pane"
                  role="tabpanel"
-                 id="report">
+                 id="report">                 
+
                 <div class="report-wrapper">
                     <div class="file-metadata-report">
                         <div id="file-metadata-modifications" data-ng-if="dictionaryViewerCtrl.changeReport.fileDataChanged.length">
                             <h3 class="change-modification-header"><i class="fa fa-exchange"></i> File Data Modifications</h3>
                             <div class="change-report-container change-modifications">
-                                <ul>
-                                    <li data-ng-repeat="change in dictionaryViewerCtrl.changeReport.fileDataChanged | filter: dictionaryViewerCtrl.filterChangesReport">
-                                        <i class="fa fa-exchange"></i> <span data-ng-bind-template="{{change.fileType}} - {{change.fileChange}}"></span>
+                                <ul class="change-report-list">
+                                    <li 
+                                      data-toggle="collapse" 
+                                      data-target="#fileMetaData{{$index}}" 
+                                      aria-expanded="false" 
+                                      data-ng-repeat="change in dictionaryViewerCtrl.changeReport.fileDataChanged | filter: dictionaryViewerCtrl.filterChangesReport" >
+                                      <i class="fa fa-exchange"></i> 
+                                      <span data-ng-bind-template="{{change.fileType}} - {{change.fileChange}}"></span>
+                                      <div class="collapse content" id="fileMetaData{{$index}}" data-ng-if="change.fileDiff" >
+                                        <div class="well" data-ng-bind-html="change.fileDiff | sanitize"></div>
+                                      </div>
                                     </li>
                                 </ul>
                             </div>
@@ -161,9 +170,16 @@
                         <div id="field-additions" data-ng-if="dictionaryViewerCtrl.changeReport.fieldsAdded.length">
                             <h3 class="change-addition-header"><i class="fa fa-plus"></i> Field Name Additions</h3>
                             <div class="change-report-container change-additions">
-                                <ul>
-                                    <li data-ng-repeat="addition in dictionaryViewerCtrl.changeReport.fieldsAdded | filter: dictionaryViewerCtrl.filterChangesReport">
+                                <ul class="change-report-list">
+                                    <li
+                                      data-toggle="collapse" 
+                                      data-target="#fieldAdded{{$index}}" 
+                                      aria-expanded="false" 
+                                      data-ng-repeat="addition in dictionaryViewerCtrl.changeReport.fieldsAdded | filter: dictionaryViewerCtrl.filterChangesReport">
                                         <i class="fa fa-plus"></i> <span data-ng-bind-template="{{addition.fileType}} - {{addition.fieldName}}"></span>
+                                        <div class="collapse content" id="fieldAdded{{$index}}" data-ng-if="addition.fieldDiff" >
+                                          <div class="well" data-ng-bind-html="addition.fieldDiff | sanitize"></div>
+                                        </div>
                                     </li>
                                 </ul>
                             </div>
@@ -171,9 +187,16 @@
                         <div id="field-modifications" data-ng-if="dictionaryViewerCtrl.changeReport.fieldsChanged.length">
                             <h3 class="change-modification-header"><i class="fa fa-exchange"></i> Field Name Modifications</h3>
                             <div class="change-report-container change-modifications">
-                                <ul>
-                                    <li data-ng-repeat="change in dictionaryViewerCtrl.changeReport.fieldsChanged | filter: dictionaryViewerCtrl.filterChangesReport">
+                                <ul class="change-report-list">
+                                    <li 
+                                      data-toggle="collapse" 
+                                      data-target="#fieldChanged{{$index}}" 
+                                      aria-expanded="false" 
+                                      data-ng-repeat="change in dictionaryViewerCtrl.changeReport.fieldsChanged | filter: dictionaryViewerCtrl.filterChangesReport">
                                         <i class="fa fa-exchange"></i> <span data-ng-bind-template="{{change.fileType}} - {{change.fieldName}}"></span>
+                                        <div class="collapse content" id="fieldChanged{{$index}}" data-ng-if="change.fieldDiff">
+                                          <div class="well" data-ng-bind-html="change.fieldDiff | sanitize"></div>
+                                        </div>
                                     </li>
                                 </ul>
                             </div>
@@ -182,9 +205,16 @@
                             <h3 class="change-removal-header"><i class="fa fa-minus"></i> Field Name Deletions</h3>
                             <div class="change-report-container change-removals">
 
-                                <ul>
-                                    <li data-ng-repeat="removal in dictionaryViewerCtrl.changeReport.fieldsRemoved | filter: dictionaryViewerCtrl.filterChangesReport">
+                                <ul class="change-report-list">
+                                    <li
+                                      data-toggle="collapse" 
+                                      data-target="#fieldRemoved{{$index}}" 
+                                      aria-expanded="false"  
+                                      data-ng-repeat="removal in dictionaryViewerCtrl.changeReport.fieldsRemoved | filter: dictionaryViewerCtrl.filterChangesReport">
                                         <i class="fa fa-minus"></i> <span data-ng-bind-template="{{removal.fileType}} - {{removal.fieldName}}"></span>
+                                        <div class="collapse content" id="fieldRemoved{{$index}}" data-ng-if="removal.fieldDiff">
+                                          <div class="well" data-ng-bind-html="removal.fieldDiff | sanitize"></div>
+                                        </div>
                                     </li>
                                 </ul>
                             </div>
@@ -195,6 +225,7 @@
                     </div>
                 </div>
             </div>
+            <p id="jsondiffpatch"></p>
             <div data-ng-class="{'active': dictionaryViewerCtrl.getCurrentView() === 'codelist'}"
                  class="tab-pane"
                  role="tabpanel"

--- a/dcc-submission-ui/dictionary/app/scripts/views/dictionary-viewer-directive.html
+++ b/dcc-submission-ui/dictionary/app/scripts/views/dictionary-viewer-directive.html
@@ -152,15 +152,14 @@
                             <div class="change-report-container change-modifications">
                                 <ul class="change-report-list">
                                     <li data-toggle="collapse" 
-                                      data-target="#fileChanged{{$index}}" 
+                                      data-target="#fileChanged{{changes.id}}" 
                                       aria-expanded="false" 
                                       data-ng-repeat="changes in dictionaryViewerCtrl.changeReport.fileDataChanged 
                                         | filter: dictionaryViewerCtrl.filterChangesReport 
                                         | findDiffs track by changes.id" >                                      
                                       <report-data-changes
-                                        changes="changes" 
-                                        type="fileChanged"
-                                        index="{{$index}}">
+                                        change="changes" 
+                                        type="fileChanged">
                                       </report-data-changes>
                                     </li>
                                 </ul>
@@ -173,15 +172,14 @@
                             <div class="change-report-container change-additions">
                                 <ul class="change-report-list">
                                   <li data-toggle="collapse" 
-                                    data-target="#fieldAdded{{$index}}" 
+                                    data-target="#fieldAdded{{additions.id}}" 
                                     aria-expanded="false" 
                                     data-ng-repeat="additions in dictionaryViewerCtrl.changeReport.fieldsAdded
                                       | filter: dictionaryViewerCtrl.filterChangesReport
                                       | findDiffs track by additions.id">
                                     <report-data-addition 
                                       addition="additions" 
-                                      type="fieldAdded"
-                                      index="{{$index}}">
+                                      type="fieldAdded">
                                     </report-data-addition>
                                 </ul>
                             </div>
@@ -191,15 +189,14 @@
                             <div class="change-report-container change-modifications">
                                 <ul class="change-report-list">
                                   <li data-toggle="collapse" 
-                                    data-target="#fieldChange{{$index}}" 
+                                    data-target="#fieldChange{{changes.id}}" 
                                     aria-expanded="false" 
-                                    data-ng-repeat="change in dictionaryViewerCtrl.changeReport.fieldsChanged 
+                                    data-ng-repeat="changes in dictionaryViewerCtrl.changeReport.fieldsChanged 
                                       | filter: dictionaryViewerCtrl.filterChangesReport 
-                                      | findDiffs track by change.id" >
+                                      | findDiffs track by changes.id" >
                                     <report-data-changes 
-                                      changes="change" 
-                                      type="fieldChange"
-                                      index="{{$index}}">
+                                      change="changes" 
+                                      type="fieldChange">
                                     </report-data-changes>
                                 </ul>
                             </div>
@@ -210,15 +207,14 @@
                                 <ul class="change-report-list">
                                     <li
                                       data-toggle="collapse" 
-                                      data-target="#fieldRemoved{{$index}}" 
+                                      data-target="#fieldRemoved{{removals.id}}" 
                                       aria-expanded="false"  
                                       data-ng-repeat="removals in dictionaryViewerCtrl.changeReport.fieldsRemoved 
                                         | filter: dictionaryViewerCtrl.filterChangesReport
                                         | findDiffs track by removals.id">
                                         <report-data-removal 
                                           removal="removals" 
-                                          type="fieldRemoved"
-                                          index="{{$index}}">
+                                          type="fieldRemoved">
                                         </report-data-removal>
                                     </li>
                                 </ul>

--- a/dcc-submission-ui/dictionary/app/scripts/views/dictionary-viewer-directive.html
+++ b/dcc-submission-ui/dictionary/app/scripts/views/dictionary-viewer-directive.html
@@ -151,17 +151,10 @@
                             <h3 class="change-modification-header"><i class="fa fa-exchange"></i> File Data Modifications</h3>
                             <div class="change-report-container change-modifications">
                                 <ul class="change-report-list">
-                                    <li 
-                                      data-toggle="collapse" 
-                                      data-target="#fileMetaData{{$index}}" 
-                                      aria-expanded="false" 
-                                      data-ng-repeat="change in dictionaryViewerCtrl.changeReport.fileDataChanged | filter: dictionaryViewerCtrl.filterChangesReport" >
-                                      <i class="fa fa-exchange"></i> 
-                                      <span data-ng-bind-template="{{change.fileType}} - {{change.fileChange}}"></span>
-                                      <div class="collapse content" id="fileMetaData{{$index}}" data-ng-if="change.fileDiff" >
-                                        <div class="well" data-ng-bind-html="change.fileDiff | sanitize"></div>
-                                      </div>
-                                    </li>
+                                    <report-data-changes
+                                        changes="dictionaryViewerCtrl.changeReport.fileDataChanged" 
+                                        type="fileChanged">
+                                    </report-data-changes>
                                 </ul>
                             </div>
                         </div>
@@ -171,16 +164,7 @@
                             <h3 class="change-addition-header"><i class="fa fa-plus"></i> Field Name Additions</h3>
                             <div class="change-report-container change-additions">
                                 <ul class="change-report-list">
-                                    <li
-                                      data-toggle="collapse" 
-                                      data-target="#fieldAdded{{$index}}" 
-                                      aria-expanded="false" 
-                                      data-ng-repeat="addition in dictionaryViewerCtrl.changeReport.fieldsAdded | filter: dictionaryViewerCtrl.filterChangesReport">
-                                        <i class="fa fa-plus"></i> <span data-ng-bind-template="{{addition.fileType}} - {{addition.fieldName}}"></span>
-                                        <div class="collapse content" id="fieldAdded{{$index}}" data-ng-if="addition.fieldDiff" >
-                                          <div class="well" data-ng-bind-html="addition.fieldDiff | sanitize"></div>
-                                        </div>
-                                    </li>
+                                    <report-data-addition changes="dictionaryViewerCtrl.changeReport.fieldsAdded" type="fieldAdded"></report-data-addition>
                                 </ul>
                             </div>
                         </div>
@@ -188,16 +172,7 @@
                             <h3 class="change-modification-header"><i class="fa fa-exchange"></i> Field Name Modifications</h3>
                             <div class="change-report-container change-modifications">
                                 <ul class="change-report-list">
-                                    <li 
-                                      data-toggle="collapse" 
-                                      data-target="#fieldChanged{{$index}}" 
-                                      aria-expanded="false" 
-                                      data-ng-repeat="change in dictionaryViewerCtrl.changeReport.fieldsChanged | filter: dictionaryViewerCtrl.filterChangesReport">
-                                        <i class="fa fa-exchange"></i> <span data-ng-bind-template="{{change.fileType}} - {{change.fieldName}}"></span>
-                                        <div class="collapse content" id="fieldChanged{{$index}}" data-ng-if="change.fieldDiff">
-                                          <div class="well" data-ng-bind-html="change.fieldDiff | sanitize"></div>
-                                        </div>
-                                    </li>
+                                    <report-data-changes changes="dictionaryViewerCtrl.changeReport.fieldsChanged" type="fieldChange"></report-data-changes>
                                 </ul>
                             </div>
                         </div>
@@ -206,7 +181,8 @@
                             <div class="change-report-container change-removals">
 
                                 <ul class="change-report-list">
-                                    <li
+                                    <report-data-removal changes="dictionaryViewerCtrl.changeReport.fieldsRemoved" type="fieldsRemoved"></report-data-removal>
+                                    <!--<li
                                       data-toggle="collapse" 
                                       data-target="#fieldRemoved{{$index}}" 
                                       aria-expanded="false"  
@@ -215,7 +191,7 @@
                                         <div class="collapse content" id="fieldRemoved{{$index}}" data-ng-if="removal.fieldDiff">
                                           <div class="well" data-ng-bind-html="removal.fieldDiff | sanitize"></div>
                                         </div>
-                                    </li>
+                                    </li>-->
                                 </ul>
                             </div>
                         </div>

--- a/dcc-submission-ui/dictionary/app/scripts/views/dictionary-viewer-directive.html
+++ b/dcc-submission-ui/dictionary/app/scripts/views/dictionary-viewer-directive.html
@@ -98,6 +98,18 @@
                                         <svg id="minimap" height="0px" width="275px" style="pointer-events:visibleFill; z-index:10"></svg>
                                     </div>
                                 </div>
+                                <div class="col-md-2 file-data-container">
+                                    <label>Version: </label>
+                                    <span>{{dictionaryViewerCtrl.vTo}}</span>
+                                </div>
+                                <div class="col-md-2 file-data-container">
+                                    <label>Last updated: </label>
+                                    <span>{{dictionaryViewerCtrl.lastUpdate | date:'shortDate'}}</span>
+                                </div>
+                                <div class="col-md-2 file-data-container">
+                                    <label>State: </label>
+                                    <span>{{dictionaryViewerCtrl.state}}</span>
+                                </div>
                                 <div class="pull-right col-md-3 detail-format-container" style="text-align: right">
                                     <label for="detail-format-type">Format: </label>
                                     <select class="form-control" id="detail-format-type"
@@ -133,40 +145,52 @@
                  role="tabpanel"
                  id="report">
                 <div class="report-wrapper">
-                    <div>
-                        <div id="additions" data-ng-if="dictionaryViewerCtrl.changeReport.added.length">
+                    <div class="file-metadata-report">
+                        <div id="file-metadata-modifications" data-ng-if="dictionaryViewerCtrl.changeReport.fileDataChanged.length">
+                            <h3 class="change-modification-header"><i class="fa fa-exchange"></i> File Data Modifications</h3>
+                            <div class="change-report-container change-modifications">
+                                <ul>
+                                    <li data-ng-repeat="change in dictionaryViewerCtrl.changeReport.fileDataChanged | filter: dictionaryViewerCtrl.filterChangesReport">
+                                        <i class="fa fa-exchange"></i> <span data-ng-bind-template="{{change.fileType}} - {{change.fileChange}}"></span>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="field-report">
+                        <div id="field-additions" data-ng-if="dictionaryViewerCtrl.changeReport.fieldsAdded.length">
                             <h3 class="change-addition-header"><i class="fa fa-plus"></i> Field Name Additions</h3>
                             <div class="change-report-container change-additions">
                                 <ul>
-                                    <li data-ng-repeat="addition in dictionaryViewerCtrl.changeReport.added | filter: dictionaryViewerCtrl.filterChangesReport">
+                                    <li data-ng-repeat="addition in dictionaryViewerCtrl.changeReport.fieldsAdded | filter: dictionaryViewerCtrl.filterChangesReport">
                                         <i class="fa fa-plus"></i> <span data-ng-bind-template="{{addition.fileType}} - {{addition.fieldName}}"></span>
                                     </li>
                                 </ul>
                             </div>
                         </div>
-                        <div id="modifications" data-ng-if="dictionaryViewerCtrl.changeReport.changed.length">
+                        <div id="field-modifications" data-ng-if="dictionaryViewerCtrl.changeReport.fieldsChanged.length">
                             <h3 class="change-modification-header"><i class="fa fa-exchange"></i> Field Name Modifications</h3>
                             <div class="change-report-container change-modifications">
                                 <ul>
-                                    <li data-ng-repeat="change in dictionaryViewerCtrl.changeReport.changed | filter: dictionaryViewerCtrl.filterChangesReport">
+                                    <li data-ng-repeat="change in dictionaryViewerCtrl.changeReport.fieldsChanged | filter: dictionaryViewerCtrl.filterChangesReport">
                                         <i class="fa fa-exchange"></i> <span data-ng-bind-template="{{change.fileType}} - {{change.fieldName}}"></span>
                                     </li>
                                 </ul>
                             </div>
                         </div>
-                        <div id="deletions" data-ng-if="dictionaryViewerCtrl.changeReport.removed.length">
+                        <div id="field-deletions" data-ng-if="dictionaryViewerCtrl.changeReport.fieldsRemoved.length">
                             <h3 class="change-removal-header"><i class="fa fa-minus"></i> Field Name Deletions</h3>
                             <div class="change-report-container change-removals">
 
                                 <ul>
-                                    <li data-ng-repeat="removal in dictionaryViewerCtrl.changeReport.removed | filter: dictionaryViewerCtrl.filterChangesReport">
+                                    <li data-ng-repeat="removal in dictionaryViewerCtrl.changeReport.fieldsRemoved | filter: dictionaryViewerCtrl.filterChangesReport">
                                         <i class="fa fa-minus"></i> <span data-ng-bind-template="{{removal.fileType}} - {{removal.fieldName}}"></span>
                                     </li>
                                 </ul>
                             </div>
                         </div>
                     </div>
-                    <div data-ng-if="! dictionaryViewerCtrl.changeReport.added.length && ! dictionaryViewerCtrl.changeReport.changed.length && ! dictionaryViewerCtrl.changeReport.removed.length">
+                    <div data-ng-if="! dictionaryViewerCtrl.changeReport.fieldsAdded.length && ! dictionaryViewerCtrl.changeReport.fieldsChanged.length && ! dictionaryViewerCtrl.changeReport.fieldsRemoved.length">
                        No Changes to Report Between {{dictionaryViewerCtrl.vFrom}} and {{dictionaryViewerCtrl.vTo}} Dictionary Versions.
                     </div>
                 </div>

--- a/dcc-submission-ui/dictionary/app/styles/dictionary.css
+++ b/dcc-submission-ui/dictionary/app/styles/dictionary.css
@@ -69,6 +69,10 @@
   padding-left: 0rem;
 }
 
+.file-data-container{
+  padding: 5px 0px;
+}
+
 .data-type-list {
   padding-left:1em;
   padding-right:1em;
@@ -252,6 +256,14 @@ a {
   margin: 1.5rem 0rem 3rem 0rem;
   border: solid 1px #e7e7e7;
   width: 80%;
+}
+
+.table.table-file-metadata tr td:first-child{
+  width:5px;
+}
+
+.table.table-file-metadata tr td:first-child.data-diff{
+  background-color: rgb(158, 123, 5);
 }
 
 .table.table-file-metadata th {

--- a/dcc-submission-ui/dictionary/app/styles/dictionary.css
+++ b/dcc-submission-ui/dictionary/app/styles/dictionary.css
@@ -361,12 +361,12 @@ div.jsoneditor-menu {
 }
 
 .change-report-container > ul > li:nth-child(even) {
-  background-color: #e7f6ec;
+  background-color: #f7f7f7;
   border: 1px solid #ccc;
 }
 
 .change-report-container > ul > li:nth-child(odd) {
-  background-color: #e7f0f7;
+  background-color: #ffffff;
   border: 1px solid #ccc;
 }
 

--- a/dcc-submission-ui/dictionary/app/styles/dictionary.css
+++ b/dcc-submission-ui/dictionary/app/styles/dictionary.css
@@ -347,27 +347,27 @@ div.jsoneditor-menu {
   margin-right: 5px;
   opacity: 1;
 }
-.change-report-container ul.change-report-list {
+.change-report-container > ul {
   margin: 0px 0px;
   padding: 0px 0px;
   list-style: none;
 }
 
-.change-report-container ul.change-report-list > li {
+.change-report-container > ul > li {
   cursor: pointer;
   line-height: 25px;
   padding: 3px;
   margin: 3px 0px;
 }
 
-.change-report-container ul.change-report-list > li:nth-child(even) {
+.change-report-container > ul > li:nth-child(even) {
   background-color: #e7f6ec;
-  border: 1px solid #c3e8d1;
+  border: 1px solid #ccc;
 }
 
-.change-report-container ul.change-report-list > li:nth-child(odd) {
+.change-report-container > ul > li:nth-child(odd) {
   background-color: #e7f0f7;
-  border: 1px solid #c3d9ec;
+  border: 1px solid #ccc;
 }
 
 .change-additions {
@@ -383,7 +383,6 @@ div.jsoneditor-menu {
 .change-modifications {
   color: rgb(146, 114, 5);
   border-color: #9e7b05;
-  background-color: #FFFFEF;
 }
 
 .change-modifications [class^='fa'] {
@@ -418,4 +417,10 @@ h3.change-addition-header {
 .jsondiffpatch-delta {
   width: 100%;
   overflow: scroll;
+}
+
+.well{
+  border-radius: 0px;
+  margin-bottom: 0px;
+  background-color: #FFF;
 }

--- a/dcc-submission-ui/dictionary/app/styles/dictionary.css
+++ b/dcc-submission-ui/dictionary/app/styles/dictionary.css
@@ -347,14 +347,27 @@ div.jsoneditor-menu {
   margin-right: 5px;
   opacity: 1;
 }
-.change-report-container ul {
+.change-report-container ul.change-report-list {
   margin: 0px 0px;
   padding: 0px 0px;
   list-style: none;
 }
 
-.change-report-container ul li {
+.change-report-container ul.change-report-list > li {
+  cursor: pointer;
   line-height: 25px;
+  padding: 3px;
+  margin: 3px 0px;
+}
+
+.change-report-container ul.change-report-list > li:nth-child(even) {
+  background-color: #e7f6ec;
+  border: 1px solid #c3e8d1;
+}
+
+.change-report-container ul.change-report-list > li:nth-child(odd) {
+  background-color: #e7f0f7;
+  border: 1px solid #c3d9ec;
 }
 
 .change-additions {
@@ -400,4 +413,9 @@ h3.change-addition-header {
 .change-removals [class^='fa'] {
   background-color: #bd1a1c;
 
+}
+
+.jsondiffpatch-delta {
+  width: 100%;
+  overflow: scroll;
 }

--- a/dcc-submission-ui/dictionary/bower.json
+++ b/dcc-submission-ui/dictionary/bower.json
@@ -32,7 +32,8 @@
     "underscore": "1.8.*",
     "regex-colorizer": "0.3.*",
     "jsoneditor": "5.1.*",
-    "bootstrap": "3.3.*"
+    "bootstrap": "3.3.*",
+    "jsondiffpatch":"0.1.43"
   },
   "devDependencies": {
     "angular-scenario": "~1.4.*"


### PR DESCRIPTION
- New **JSONDiffPatch** library introduced to bower
- Added library JS files and JSONDiffPatch config to index.html
- Introduced **new filter** to trust data passed by angular as HTML
- Added sorting of files before looking for changes
- New values added to the change report JSON for angularJS to pickup on the front-end
- New HTML content to show the differences in change log
- Styling updated to the change log
- JSHint Error fix. Added 'jsondiffpatch' to JSHint globals so the test task ignores it and runs without any issue. 
