### PR TITLE
Add tasks to pack dictionary viewer as npm module

### DIFF
--- a/dcc-submission-ui/dictionary/.gitignore
+++ b/dcc-submission-ui/dictionary/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 app/bower_components
 build
+dist
+.tmp

--- a/dcc-submission-ui/dictionary/Gruntfile.js
+++ b/dcc-submission-ui/dictionary/Gruntfile.js
@@ -22,7 +22,9 @@ module.exports = function (grunt) {
   // configurable paths
   var yeomanConfig = {
     app: 'app',
-    dist: '../public/dictionary'
+    dist: '../public/dictionary',
+    moduleDist: 'dist',
+    tmp: '.tmp',
   };
 
 
@@ -158,9 +160,16 @@ module.exports = function (grunt) {
     },
     // not used since Uglify task does concat,
     // but still available if needed
-    /*concat: {
-     dist: {}
-     },*/
+    concat: {
+      dist: {
+        src: [
+          'npm-module-scripts/imports.js',
+          '<%= yeoman.app %>/scripts/**/*.js',
+          '<%= yeoman.tmp %>/templates.js'
+        ],
+        dest: '<%= yeoman.moduleDist %>/dictionary.js',
+      }
+    },
     // Renames files for browser caching purposes
     filerev: {
       dist: {
@@ -178,7 +187,7 @@ module.exports = function (grunt) {
         flow: {
           html: {
             steps: {
-              js: ['concat'],
+              // js: ['concat'],
               css: ['concat', 'cssmin']
             },
             post: {}
@@ -344,7 +353,19 @@ module.exports = function (grunt) {
           dest: '<%= yeoman.dist %>/scripts',
           ext: '.js'
         }]
-
+      },
+    },
+    ngtemplates:    {
+      app:          {
+        cwd:        'app',
+        src:        'scripts/views/*.html',
+        dest:       '<%= yeoman.tmp %>/templates.js',
+        options:    {
+          htmlmin:  { collapseWhitespace: true, collapseBooleanAttributes: true },
+          bootstrap: function (module, script) {
+            return 'angular.module(\'DictionaryViewerApp\').run([\'$templateCache\', function($templateCache) {' + script + '} ]);';
+          }
+        }
       }
     }
   });
@@ -382,7 +403,7 @@ module.exports = function (grunt) {
     //'karma',
     'useminPrepare',
     'concurrent:dist',
-    'concat',
+    // 'concat',
     'copy:dist',
     'ngAnnotate',
     'cssmin',

--- a/dcc-submission-ui/dictionary/Gruntfile.js
+++ b/dcc-submission-ui/dictionary/Gruntfile.js
@@ -363,7 +363,8 @@ module.exports = function (grunt) {
         options:    {
           htmlmin:  { collapseWhitespace: true, collapseBooleanAttributes: true },
           bootstrap: function (module, script) {
-            return 'angular.module(\'DictionaryViewerApp\').run([\'$templateCache\', function($templateCache) {' + script + '} ]);';
+            return 'angular.module(\'DictionaryViewerApp\').run([\'$templateCache\', function($templateCache) {' +
+              script + '} ]);';
           }
         }
       }

--- a/dcc-submission-ui/dictionary/README.md
+++ b/dcc-submission-ui/dictionary/README.md
@@ -1,0 +1,18 @@
+The DCC docs site depends on this package for its dictionary viewer.
+
+For the Docs site to receive updates, a new version of [@icgc/dictionary-viewer](https://www.npmjs.com/package/@icgc/dictionary-viewer) will need to be published, and the dependency on the docs site will need to be updated.
+
+An example for minor patch updates - 
+```bash
+npm version patch
+npm publish
+```
+
+The above commands will  
+
+1. bump `package.json`'s patch version by 1
+2. commit the change and push to github
+3. trigger the prepublish command which builds the package
+4. publish the new version to npm
+
+After the new version is published, remember to update the dependency on the Docs site to receive the update

--- a/dcc-submission-ui/dictionary/app/scripts/directives/dictionary-viewer-directive.js
+++ b/dcc-submission-ui/dictionary/app/scripts/directives/dictionary-viewer-directive.js
@@ -433,7 +433,7 @@ angular.module('DictionaryViewerApp')
         change: '=',
         type: '@'
       },
-      templateURL: 'scripts/views/data-changes.html'
+      templateUrl: 'scripts/views/data-changes.html'
     };
   })
   .directive('reportDataAddition', function($http, $templateCache, $compile){    

--- a/dcc-submission-ui/dictionary/app/scripts/directives/dictionary-viewer-directive.js
+++ b/dcc-submission-ui/dictionary/app/scripts/directives/dictionary-viewer-directive.js
@@ -426,7 +426,7 @@ angular.module('DictionaryViewerApp')
     };
 
   })
-  .directive('reportDataChanges', function($http, $templateCache, $compile){    
+  .directive('reportDataChanges', function(){    
     return {      
       restrict: 'E',
       scope: {
@@ -436,7 +436,7 @@ angular.module('DictionaryViewerApp')
       templateUrl: 'scripts/views/data-changes.html'
     };
   })
-  .directive('reportDataAddition', function($http, $templateCache, $compile){    
+  .directive('reportDataAddition', function(){    
     return {      
       restrict: 'E',
       scope: {
@@ -446,7 +446,7 @@ angular.module('DictionaryViewerApp')
       templateUrl: 'scripts/views/data-addition.html',
     };
   })
-  .directive('reportDataRemoval', function($http, $templateCache, $compile){   
+  .directive('reportDataRemoval', function(){   
     return {      
       restrict: 'E',
       scope: {

--- a/dcc-submission-ui/dictionary/app/scripts/directives/dictionary-viewer-directive.js
+++ b/dcc-submission-ui/dictionary/app/scripts/directives/dictionary-viewer-directive.js
@@ -13,7 +13,7 @@ angular.module('DictionaryViewerApp')
                                           $templateCache, $compile, DictionaryAppConstants) {
     return {
       restrict: 'EA',
-      //templateUrl: 'scripts/views/dictionary-viewer-directive.html',
+      templateUrl: 'scripts/views/dictionary-viewer-directive.html',
       scope: {
         baseDictionaryUrl: '@',
         showHeaderNav: '@',
@@ -422,26 +422,7 @@ angular.module('DictionaryViewerApp')
 
         }
       },
-      controllerAs: 'dictionaryViewerCtrl',
-      link: function(scope, element, attrs) {
-        var relTemplateURL = 'scripts/views/dictionary-viewer-directive.html',
-            baseURL = '';
-
-        if (angular.isDefined(attrs.templateUrl)) {
-          baseURL = attrs.templateUrl;
-        }
-        else if (angular.isDefined(attrs.baseDictionaryUrl)) {
-          baseURL = attrs.baseDictionaryUrl;
-        }
-
-        if (baseURL) {
-          baseURL += '/';
-        }
-
-        $http.get(baseURL + relTemplateURL, {cache: $templateCache}).success(function(tplContent){
-          element.replaceWith($compile(tplContent)(scope));
-        });
-      }
+      controllerAs: 'dictionaryViewerCtrl'
     };
 
   })
@@ -452,25 +433,7 @@ angular.module('DictionaryViewerApp')
         change: '=',
         type: '@'
       },
-      link: function(scope, element, attrs) {
-        var relTemplateURL = 'scripts/views/data-changes.html',
-            baseURL = '';
-
-        if (angular.isDefined(attrs.templateUrl)) {
-          baseURL = attrs.templateUrl;
-        }
-        else if (angular.isDefined(attrs.baseDictionaryUrl)) {
-          baseURL = attrs.baseDictionaryUrl;
-        }
-
-        if (baseURL) {
-          baseURL += '/';
-        }
-
-        $http.get(baseURL + relTemplateURL, {cache: $templateCache}).success(function(tplContent){
-          element.replaceWith($compile(tplContent)(scope));
-        });
-      }
+      templateURL: 'scripts/views/data-changes.html'
     };
   })
   .directive('reportDataAddition', function($http, $templateCache, $compile){    
@@ -480,25 +443,7 @@ angular.module('DictionaryViewerApp')
         addition: '=',
         type: '@'
       },
-      link: function(scope, element, attrs) {
-        var relTemplateURL = 'scripts/views/data-addition.html',
-            baseURL = '';
-
-        if (angular.isDefined(attrs.templateUrl)) {
-          baseURL = attrs.templateUrl;
-        }
-        else if (angular.isDefined(attrs.baseDictionaryUrl)) {
-          baseURL = attrs.baseDictionaryUrl;
-        }
-
-        if (baseURL) {
-          baseURL += '/';
-        }
-
-        $http.get(baseURL + relTemplateURL, {cache: $templateCache}).success(function(tplContent){
-          element.replaceWith($compile(tplContent)(scope));
-        });
-      }
+      templateUrl: 'scripts/views/data-addition.html',
     };
   })
   .directive('reportDataRemoval', function($http, $templateCache, $compile){   
@@ -508,24 +453,6 @@ angular.module('DictionaryViewerApp')
         removal: '=',
         type: '@'
       },
-      link: function(scope, element, attrs) {
-        var relTemplateURL = 'scripts/views/data-removal.html',
-            baseURL = '';
-
-        if (angular.isDefined(attrs.templateUrl)) {
-          baseURL = attrs.templateUrl;
-        }
-        else if (angular.isDefined(attrs.baseDictionaryUrl)) {
-          baseURL = attrs.baseDictionaryUrl;
-        }
-
-        if (baseURL) {
-          baseURL += '/';
-        }
-
-        $http.get(baseURL + relTemplateURL, {cache: $templateCache}).success(function(tplContent){
-          element.replaceWith($compile(tplContent)(scope));
-        });
-      }
+      templateUrl: 'scripts/views/data-removal.html'
     };
   });

--- a/dcc-submission-ui/dictionary/app/scripts/views/dictionary-viewer-directive.html
+++ b/dcc-submission-ui/dictionary/app/scripts/views/dictionary-viewer-directive.html
@@ -226,7 +226,7 @@
                     </div>
                 </div>
             </div>
-            <p id="jsondiffpatch"></p>
+            <p id="jsondiffpatch-el"></p>
             <div data-ng-class="{'active': dictionaryViewerCtrl.getCurrentView() === 'codelist'}"
                  class="tab-pane"
                  role="tabpanel"

--- a/dcc-submission-ui/dictionary/app/styles/dictionary.css
+++ b/dcc-submission-ui/dictionary/app/styles/dictionary.css
@@ -415,12 +415,12 @@ h3.change-addition-header {
 }
 
 .jsondiffpatch-delta {
-  width: 100%;
-  overflow: scroll;
+  width: 100% !important;
+  overflow: scroll !important;
 }
 
 .well{
-  border-radius: 0px;
-  margin-bottom: 0px;
-  background-color: #FFF;
+  border-radius: 0px !important;
+  margin-bottom: 0px !important;
+  background-color: #FFF !important;
 }

--- a/dcc-submission-ui/dictionary/npm-module-scripts/imports.js
+++ b/dcc-submission-ui/dictionary/npm-module-scripts/imports.js
@@ -1,0 +1,17 @@
+var angular = require('angular');
+require('angular-sanitize');
+require('angular-animate');
+require('angular-loading-bar');
+var highlightjs = require('highlight.js/lib/highlight.js');
+var _ = require('underscore');
+var RegexColorizer = require('regex-colorizer');
+require('bootstrap');
+var d3 = require('d3');
+require('d3-tip')(d3);
+var js_beautify = require('js-beautify').js_beautify;
+var JSONEditor = require('jsoneditor/dist/jsoneditor.js');
+
+global.jsondiffpatch = require('jsondiffpatch');
+global.jsondiffpatch.formatters = {
+  html: require('jsondiffpatch/src/formatters/html')
+};

--- a/dcc-submission-ui/dictionary/package.json
+++ b/dcc-submission-ui/dictionary/package.json
@@ -1,16 +1,45 @@
 {
-  "name": "dcc-submission-dictionary-viewer",
-  "description": "ICGC Submission Dictionary Viewer",
-  "version": "1.0.0",
+  "name": "@icgc/dictionary-viewer",
+  "description": "ICGC Dictionary Viewer",
+  "version": "1.0.3",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com:icgc-dcc/dcc-submission.git"
   },
+  "main": "dist/dictionary.js",
+  "scripts": {
+    "build:module": "grunt ngtemplates && grunt concat",
+    "prepublish": "npm run build:module"
+  },
+  "files": [
+    "dist",
+    "app/fonts",
+    "app/images",
+    "app/styles"
+  ],
+  "dependencies": {
+    "angular": "~1.4.*",
+    "angular-animate": "~1.4.*",
+    "angular-loading-bar": "0.9.0",
+    "angular-mocks": "~1.4.*",
+    "angular-sanitize": "~1.4.*",
+    "bootstrap": "3.3.*",
+    "d3": "3.5.6",
+    "d3-tip": "0.6.*",
+    "highlight.js": "9.0.*",
+    "jquery": "1.9.*",
+    "json": "9.0.4",
+    "jsondiffpatch": "0.1.43",
+    "jsoneditor": "5.1.*",
+    "regex-colorizer": "0.3.*",
+    "underscore": "1.8.*"
+  },
   "devDependencies": {
     "connect-livereload": "0.5.0",
     "connect-modrewrite": "0.5.6",
     "grunt": "~0.4.*",
+    "grunt-angular-templates": "1.1.0",
     "grunt-bower-install-simple": "~1.1.*",
     "grunt-concurrent": "0.3.0",
     "grunt-contrib-clean": "~0.4.1",
@@ -24,12 +53,13 @@
     "grunt-contrib-jshint": "~0.11.*",
     "grunt-contrib-uglify": "~0.11.*",
     "grunt-contrib-watch": "0.6.1",
+    "grunt-filerev": "~2.3.*",
     "grunt-karma": "0.10.1",
     "grunt-ng-annotate": "~0.9.*",
     "grunt-open": "0.2.0",
-    "grunt-filerev": "~2.3.*",
     "grunt-usemin": "3.0.0",
     "http-proxy": "0.10.0",
+    "imports-loader": "0.6.5",
     "jshint-stylish": "^2.1.0",
     "karma": "~0.12.31",
     "karma-chrome-launcher": "~0.1.7",

--- a/dcc-submission-ui/dictionary/package.json
+++ b/dcc-submission-ui/dictionary/package.json
@@ -29,6 +29,7 @@
     "d3-tip": "0.6.*",
     "highlight.js": "9.0.*",
     "jquery": "1.9.*",
+    "js-beautify": "1.6.3",
     "json": "9.0.4",
     "jsondiffpatch": "0.1.43",
     "jsoneditor": "5.1.*",

--- a/dcc-submission-ui/dictionary/package.json
+++ b/dcc-submission-ui/dictionary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@icgc/dictionary-viewer",
   "description": "ICGC Dictionary Viewer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/dcc-submission-ui/dictionary/package.json
+++ b/dcc-submission-ui/dictionary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@icgc/dictionary-viewer",
   "description": "ICGC Dictionary Viewer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/dcc-submission-ui/package.json
+++ b/dcc-submission-ui/package.json
@@ -17,21 +17,19 @@
     "test": "brunch test"
   },
   "dependencies": {
-    "javascript-brunch": "1.3.0",
-    "coffeelint": "1.0.1",
-    "coffee-script-brunch": "1.4.1",
-
-    "css-brunch": "1.3.0",
-    "stylus-brunch": "1.4.3",
-    "less-brunch": "1.4.1",
-
-    "handlebars-brunch": "1.4.0",
-
-    "uglify-js-brunch": "1.3.1",
+    "auto-reload-brunch": "1.6.5",
     "clean-css-brunch": "1.4.0",
-
+    "coffee-script-brunch": "1.4.1",
+    "coffeelint": "1.0.1",
     "coffeelint-brunch": "1.4.4",
-    "auto-reload-brunch": "1.6.5"
+    "css-brunch": "1.3.0",
+    "handlebars-brunch": "1.4.0",
+    "javascript-brunch": "1.3.0",
+    "jquery": "3.1.0",
+    "js-beautify": "1.6.3",
+    "less-brunch": "1.4.1",
+    "stylus-brunch": "1.4.3",
+    "uglify-js-brunch": "1.3.1"
   },
   "devDependencies": {
     "http-proxy": "0.10.0",


### PR DESCRIPTION
To build dictionary viewer as npm module:

```
npm run build:module
```

To publish to npm

```
npm version patch
npm publish
```

(the prepublish will automatically trigger a build so you don't need to manually build before publishing)
