### PR TITLE
Bugfix: zoom icon should not block clicks

### DIFF
--- a/dcc-submission-ui/dictionary/app/styles/dictionary.css
+++ b/dcc-submission-ui/dictionary/app/styles/dictionary.css
@@ -224,6 +224,10 @@ a {
   position: relative;
 }
 
+.code-container .fa {
+  pointer-events: none;
+}
+
 .code-zoom-indicator {
   position: absolute;
   bottom: 5px;


### PR DESCRIPTION
Fixed issue with having to click off of the icon

![image](https://cloud.githubusercontent.com/assets/743976/18056451/ed958d92-6dd9-11e6-97eb-347b3f6c60a0.png)
