### PR TITLE
bugfix: UI breaks on null values for `fieldNames`

### DIFF
--- a/dcc-submission-ui/src/Report/ErrorReport/processAndDenormalizeErrors.js
+++ b/dcc-submission-ui/src/Report/ErrorReport/processAndDenormalizeErrors.js
@@ -6,9 +6,10 @@ export default function processAndDenormalizeErrors (errorReports) {
   return flatten(errorReports.map( errorReport => errorReport.fieldErrorReports.map(
     fieldErrorReport => ({
       ...fieldErrorReport,
-      errorType: errorReport.errorType, 
+      errorType: errorReport.errorType,
+      fieldNames: fieldErrorReport.fieldNames || [],
       lineValueMap: zipObject(fieldErrorReport.lineNumbers, fieldErrorReport.values),
       lineNumbers: fieldErrorReport.lineNumbers.sort((a, b) => a - b),
-      key: `${errorReport.errorType}&${fieldErrorReport.fieldNames.join('&')}`,
+      key: `${errorReport.errorType}&${(fieldErrorReport.fieldNames || []).join('&')}`,
     }))));
 };


### PR DESCRIPTION
fixes 

> Release page freezes with projects loading.

and

> Report is not displayed

 for https://jira.oicr.on.ca/browse/DCC-5378

Was caused by JS error due to not accounting for fieldErrorReports.fieldNames potentially containing having `null` value
